### PR TITLE
cosmetic changes in build_cause message - use unordered list instead …

### DIFF
--- a/models/services/get_build_cause.rb
+++ b/models/services/get_build_cause.rb
@@ -18,11 +18,15 @@ module GitlabWebHook
       else
         notes << "triggered by push on branch #{details.full_branch_reference}"
         notes << "with #{details.commits_count} commit#{details.commits_count == '1' ? '' : 's' }:"
+        commit_notes = ['<ul>']
         details.commits.each do |commit|
-          notes << "* <a href=\"#{commit.url}\">#{commit.message}</a>"
+          commit_notes << "<li> <a href=\"#{commit.url}\">#{commit.message}</a> by #{commit.author_name}</li>"
         end
+        commit_notes <<  "</ul>"
+        notes << commit_notes.join
       end
       notes
     end
   end
 end
+

--- a/models/values/commit.rb
+++ b/models/values/commit.rb
@@ -1,10 +1,11 @@
 module GitlabWebHook
   class Commit
-    attr_reader :url, :message
+    attr_reader :url, :message, :author_name
 
-    def initialize(url, message)
+    def initialize(url, message, author_name)
       @url = url
       @message = message
+      @author_name = author_name
     end
   end
 end

--- a/models/values/payload_request_details.rb
+++ b/models/values/payload_request_details.rb
@@ -43,7 +43,7 @@ module GitlabWebHook
 
     def get_commits
       @commits ||= payload["commits"].to_a.map do |commit|
-        Commit.new(commit["url"], commit["message"])
+        Commit.new(commit["url"], commit["message"],  commit["author"]["name"])
       end
     end
 

--- a/spec/values/commit_spec.rb
+++ b/spec/values/commit_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module GitlabWebHook
   describe Commit do
-    let(:subject) { Commit.new('http://localhost/diaspora/diaspora/commits/450d0de7532f', 'Update Catalan translation') }
+    let(:subject) { Commit.new('http://localhost/diaspora/diaspora/commits/450d0de7532f', 'Update Catalan translation', 'John Doe') }
 
     it 'has commit url' do
       expect(subject).to respond_to(:url)
@@ -13,5 +13,11 @@ module GitlabWebHook
       expect(subject).to respond_to(:message)
       expect(subject.message).to eq('Update Catalan translation')
     end
+
+    it 'has author name' do
+      expect(subject).to respond_to(:author_name)
+      expect(subject.author_name).to eq('John Doe')
+    end
+
   end
 end


### PR DESCRIPTION
…<br> tag and print author name after commit message
My developers were unhappy when they can't see author of commit on jenkins build page