### PR TITLE
fix parse error if repo url contains port number

### DIFF
--- a/models/gitlab_notifier.rb
+++ b/models/gitlab_notifier.rb
@@ -138,7 +138,7 @@ class GitlabNotifier < Jenkins::Tasks::Publisher
   def repo_namespace(build)
     @project = GitlabWebHook::Project.new build.native.project
     repo_url = @project.scm.repositories.first.getURIs.first
-    repo_url.to_s.split(':')[1]
+    repo_url.to_s.split(':', 2)[1]
   end
 
 end


### PR DESCRIPTION
If the GIT repository URL contains port number (e.g. ssh://git@gitlab.company.com:1234/group1/repo1.git), the commit status notifier will parse the name of the repository as "git@gitlab" instead of the expected "repo1".