### PR TITLE
update string as proposed in JENKINS-29458

### DIFF
--- a/views/gitlab_notifier/help-gitlab_url.erb
+++ b/views/gitlab_notifier/help-gitlab_url.erb
@@ -1,1 +1,1 @@
-Full endpoint for gitlab API (e.g. https://gitlab.com/api/v3).
+URL to your gitlab instance (e.g. https://gitlab.example.com).


### PR DESCRIPTION
The documentation states that Gitlab URL should be the full URL, including /api/v3 (Full endpoint for gitlab API (e.g. https://gitlab.com/api/v3)). This seems to be wrong.

https://issues.jenkins-ci.org/browse/JENKINS-29458