### PR TITLE
Allow matching against sub-string of description field on auto job creation

### DIFF
--- a/jenkins-gitlab-hook.pluginspec
+++ b/jenkins-gitlab-hook.pluginspec
@@ -1,7 +1,7 @@
 Jenkins::Plugin::Specification.new do |plugin|
   plugin.name = "gitlab-hook"
   plugin.display_name = "Gitlab Hook Plugin"
-  plugin.version = '1.4.1MS'
+  plugin.version = '1.4.1'
   plugin.description = 'Enables Gitlab web hooks to be used to trigger SMC polling on Gitlab projects'
 
   plugin.url = 'https://wiki.jenkins-ci.org/display/JENKINS/Gitlab+Hook+Plugin'

--- a/jenkins-gitlab-hook.pluginspec
+++ b/jenkins-gitlab-hook.pluginspec
@@ -1,7 +1,7 @@
 Jenkins::Plugin::Specification.new do |plugin|
   plugin.name = "gitlab-hook"
   plugin.display_name = "Gitlab Hook Plugin"
-  plugin.version = '1.4.1'
+  plugin.version = '1.4.1MS'
   plugin.description = 'Enables Gitlab web hooks to be used to trigger SMC polling on Gitlab projects'
 
   plugin.url = 'https://wiki.jenkins-ci.org/display/JENKINS/Gitlab+Hook+Plugin'

--- a/models/root_action_descriptor.rb
+++ b/models/root_action_descriptor.rb
@@ -59,6 +59,7 @@ class GitlabWebHookRootActionDescriptor < Jenkins::Model::DefaultDescriptor
       @description                  = read_property(doc, DESCRIPTION_PROPERTY)
       @templates                    = get_templates doc.root.elements['templates']
       @group_templates              = get_templates doc.root.elements['group_templates']
+      @description_templates        = get_templates doc.root.elements['description_templates']
       @template                     = doc.root.elements['template'] && doc.root.elements['template'].text
     end
   end
@@ -90,6 +91,13 @@ class GitlabWebHookRootActionDescriptor < Jenkins::Model::DefaultDescriptor
       new.add_element('project').add_text(v)
     end
 
+    tpls = doc.root.add_element( 'description_templates' )
+    templated_descriptions.each do |k,v|
+      new = tpls.add_element('template')
+      new.add_element('string').add_text(k)
+      new.add_element('project').add_text(v)
+    end
+
     tpls = doc.root.add_element( 'group_templates' )
     templated_groups.each do |k,v|
       new = tpls.add_element('template')
@@ -114,6 +122,10 @@ class GitlabWebHookRootActionDescriptor < Jenkins::Model::DefaultDescriptor
     @templates || {}
   end
 
+  def templated_descriptions
+    @description_templates || {}
+  end
+
   def templated_groups
     @group_templates || {}
   end
@@ -135,6 +147,9 @@ class GitlabWebHookRootActionDescriptor < Jenkins::Model::DefaultDescriptor
     end
     @template = form['template']
     @templates = form['templates'] && form2list( form['templates'] ).inject({}) do |hash, item|
+      hash.update( item['string'] => item['project'] )
+    end
+    @description_templates = form['description_templates'] && form2list( form['description_templates'] ).inject({}) do |hash, item|
       hash.update( item['string'] => item['project'] )
     end
     @group_templates = form['group_templates'] && form2list( form['group_templates'] ).inject({}) do |hash, item|

--- a/models/use_cases/process_commit.rb
+++ b/models/use_cases/process_commit.rb
@@ -44,6 +44,12 @@ module GitlabWebHook
           end
         end
         return if projects.any?
+        settings.templated_descriptions.each do |matchstr,template|
+          if details.repository_description.index matchstr
+            projects << @create_project_for_branch.from_template(template, details)
+          end
+        end
+        return if projects.any?
         settings.templated_groups.each do |matchstr,template|
           if details.repository_group == matchstr
             projects << @create_project_for_branch.from_template(template, details)

--- a/models/values/payload_request_details.rb
+++ b/models/values/payload_request_details.rb
@@ -24,6 +24,12 @@ module GitlabWebHook
       payload["repository"]["name"].strip
     end
 
+    def repository_description
+      return "" unless payload["repository"]
+      return "" unless payload["repository"]["description"]
+      payload["repository"]["description"].strip
+    end
+
     def repository_homepage
       return "" unless payload["repository"]
       return "" unless payload["repository"]["homepage"]

--- a/views/gitlab_web_hook_root_action/global.erb
+++ b/views/gitlab_web_hook_root_action/global.erb
@@ -49,6 +49,19 @@ An already existing jenkins project will be used as base, and different kind of 
 
       end
 
+      f.entry :title => 'Templates for project description', :description => 'The incoming repository description is compared with the match string' do
+        f.repeatable :items => descriptor.templated_descriptions.to_a, :var => 'description_templates', :add => 'Add new description template' do
+          %><table width="100%"><%
+          f.entry :title => 'Match string', :field => 'string' do
+            f.textbox :default => "#{description_templates.nil? ? '' : description_templates.first }"
+          end
+          f.entry :title => 'Base project', :field => 'project' do
+            f.textbox :default => "#{description_templates.nil? ? '' : description_templates.last }"
+          end
+          %></table><div align="right"><%f.repeatableDeleteButton%></div><%
+        end
+      end
+
       f.entry :title => 'Templates for gitlab groups', :description => 'Full string comparison is performed with the incoming repository' do
         f.repeatable :items => descriptor.templated_groups.to_a, :var => 'group_templates', :add => 'Add new group template' do
           %><table width="100%"><%


### PR DESCRIPTION
This change adds a third option to selecting a template to use when performing auto job creation. A match is made against a sub-string of the repository description passed in the payload.

We needed this as it was found that, due to our naming conventions, the existing options didn't provide sufficient flexibility.