### PR TITLE
Fix null pointer related to SECURITY-263

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,8 @@ No special options are required to execute the test on recent JRuby versions (su
 ## Development
 
 Locally building:
-- Download latest stable jruby tar
+- Download latest stable jruby tar, recommended to be in 1.9 mode
+-- `rvm install jruby-1.7.27 --1.9`  
 - Extract and add bin/ directory to your $PATH
 - To install run:
 -- `export GEM_HOME=~/.ruby/gems`
@@ -258,7 +259,7 @@ Locally building:
 To test locally in Jenkins
 - Download latest Jenkins distribution
 - Extract and run `java -jar jenkins.war`
-- Upload `pkg/gitlab-hook-nojenkinscommits.hpi` into Jenkins manual install interface
+- Upload `pkg/gitlab-hook.hpi` into Jenkins manual install interface
 
-Example post bodies are available on the [gitlab webhook page](https://gitlab.com/gitlab-org/gitlab-ce/blob/master/doc/web_hooks/web_hooks.md)
+Example post bodies are available on the [gitlab webhook page](https://gitlab.com/gitlab-org/gitlab-ce/blob/master/doc/user/project/integrations/webhooks.md)
 

--- a/jenkins-gitlab-hook.pluginspec
+++ b/jenkins-gitlab-hook.pluginspec
@@ -1,7 +1,7 @@
 Jenkins::Plugin::Specification.new do |plugin|
   plugin.name = "gitlab-hook"
   plugin.display_name = "Gitlab Hook Plugin"
-  plugin.version = '1.4.2'
+  plugin.version = '1.4.3'
   plugin.description = 'Enables Gitlab web hooks to be used to trigger SMC polling on Gitlab projects'
 
   plugin.url = 'https://wiki.jenkins-ci.org/display/JENKINS/Gitlab+Hook+Plugin'

--- a/models/gitlab_notifier.rb
+++ b/models/gitlab_notifier.rb
@@ -72,7 +72,7 @@ class GitlabNotifier < Jenkins::Tasks::Publisher
     attr_reader :gitlab_url
 
     def token
-      @token.get_plain_text
+      Secret.toString @token
     end
 
     def commit_status?


### PR DESCRIPTION
I'm working on a different addition to this but in trying to set up my environment I ran into this issue. Basically on a fresh install of jenkins or when installing this plugin for the first time with the SECURITY-263 fix the configure page would crash on me.

Also updated the readme to reflect some of what I experience in my setup. 

Note with latest ruby there are some changes to the DIr class which affects the Spec files the most, `spec/plugins/WEB-INF/classes` would only work for me if I change it to `/spec/plugins/WEB-INF/classes` but I haven't looked deeper into this.