### PR TITLE
add support for triggering multibranch pipeline projects

### DIFF
--- a/models/services/get_build_cause.rb
+++ b/models/services/get_build_cause.rb
@@ -1,6 +1,7 @@
 include Java
 
 java_import Java.hudson.model.Cause
+java_import Java.hudson.model.CauseAction
 
 module GitlabWebHook
   class GetBuildCause
@@ -8,7 +9,7 @@ module GitlabWebHook
       raise ArgumentError.new('details are required') unless details
 
       notes = details.payload ? from_payload(details) : 'no payload available'
-      Cause::RemoteCause.new(details.repository_uri.host, notes)
+      CauseAction.new(Cause::RemoteCause.new(details.repository_uri.host, notes))
     end
 
     def from_payload(details)

--- a/models/use_cases/build_now.rb
+++ b/models/use_cases/build_now.rb
@@ -8,6 +8,7 @@ module GitlabWebHook
 
     java_import Java.java.util.logging.Logger
     java_import Java.java.util.logging.Level
+    java_import Java.hudson.model.Action
 
     def initialize(project, logger = Logger.getLogger(self.class.name))
       raise ArgumentError.new('project is required') unless project
@@ -21,7 +22,11 @@ module GitlabWebHook
       raise ArgumentError.new('details are required') unless details
 
       begin
-        return "#{project} scheduled for build" if project.scheduleBuild2(project.getQuietPeriod(), cause_builder.with(details), actions_builder.with(project, details))
+        actions = [cause_builder.with(details)]
+        if project.multibranchProject?
+            actions.concat actions_builder.with(project, details)
+        end
+        return "#{project} scheduled for build" if project.scheduleBuild2(project.getQuietPeriod(), actions.to_java(Action))
       rescue java.lang.Exception => e
         # avoid method signature warnings
         severe = logger.java_method(:log, [Level, java.lang.String, java.lang.Throwable])

--- a/models/use_cases/notify_commit.rb
+++ b/models/use_cases/notify_commit.rb
@@ -18,7 +18,11 @@ module GitlabWebHook
       return "#{project} is not buildable (it is disabled or not saved), skipping polling" unless project.buildable?
 
       begin
-        return "#{project} scheduled for polling" if project.schedulePolling
+        if project.multibranchProject?
+          return "#{project} scheduled for polling" if project.scheduleBuild
+        else
+          return "#{project} scheduled for polling" if project.schedulePolling
+        end
       rescue java.lang.Exception => e
         # avoid method signature warnings
         severe = logger.java_method(:log, [Level, java.lang.String, java.lang.Throwable])


### PR DESCRIPTION
Adds support for triggering multibranch pipeline jobs, in particular for global hooks. This relies on the scan functionality of the multibranch jobs, once it detects the SCM Uri. 

Currently in `def matches?(details, branch = false, exactly = false)` I always return true, for a multibranch job since the uri has already been found. I know it would pass the `matches_branch?` but I don't see the point of traversing all the branches. In theory I think I should make `setup_scms` only grab the first branch it finds as well since that's all we need to get a SCM repo Uri.

This request only covers branches and not merge request. I'm looking into that next, but this seem self contained enough and worth adding to the main project. Also maybe you noticed something I missed as I continue down this path. 

General note, these multibranch jobs extend from `hudson.model.AbstractItem` -> `com.cloudbees.hudson.plugins.folder.AbstractFolder` so that's why I made some decisions that I did since I couldn't use `AbstractProject`. I also decided to be more specific for the same reason's as I don't know how all `AbstractFolder` behave.
